### PR TITLE
v1.0.4: add setDevice and setWirePort

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,6 +12,8 @@ SFE_MAX17043	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
+setDevice	KEYWORD2
+setWirePort	KEYWORD2
 begin	KEYWORD2
 isConnected	KEYWORD2
 enableDebugging	KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun MAX1704x Fuel Gauge Arduino Library
-version=1.0.3
+version=1.0.4
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Arduino library for the MAX17043/44/48/49 fuel gauges

--- a/src/SparkFun_MAX1704x_Fuel_Gauge_Arduino_Library.cpp
+++ b/src/SparkFun_MAX1704x_Fuel_Gauge_Arduino_Library.cpp
@@ -23,7 +23,12 @@ Distributed as-is; no warranty is given.
 SFE_MAX1704X::SFE_MAX1704X(sfe_max1704x_devices_e device)
 {
   // Constructor
+  setDevice(device);
+}
 
+// Change the device type if required. Do this after instantiation but before .begin
+void SFE_MAX1704X::setDevice(sfe_max1704x_devices_e device)
+{
   // Record the device type
   _device = device;
 
@@ -45,9 +50,9 @@ SFE_MAX1704X::SFE_MAX1704X(sfe_max1704x_devices_e device)
   }
 }
 
-boolean SFE_MAX1704X::begin(TwoWire &wirePort)
+bool SFE_MAX1704X::begin(TwoWire &wirePort)
 {
-  _i2cPort = &wirePort; //Grab which port the user wants us to use
+  setWirePort(wirePort); //Grab which port the user wants us to use
 
   if (isConnected() == false)
   {
@@ -63,8 +68,14 @@ boolean SFE_MAX1704X::begin(TwoWire &wirePort)
   return (true);
 }
 
+// Allow _i2CPort to be set manually, so that isConnected can be called before .begin if required
+void SFE_MAX1704X::setWirePort(TwoWire &wirePort)
+{
+  _i2cPort = &wirePort; //Grab which port the user wants us to use
+}
+
 //Returns true if device is present
-boolean SFE_MAX1704X::isConnected(void)
+bool SFE_MAX1704X::isConnected(void)
 {
   //Updated to resolve issue #4 Dec 27th 2021
   //Also avoid using the standard "if device answers on _deviceAddress" test

--- a/src/SparkFun_MAX1704x_Fuel_Gauge_Arduino_Library.h
+++ b/src/SparkFun_MAX1704x_Fuel_Gauge_Arduino_Library.h
@@ -133,11 +133,17 @@ class SFE_MAX1704X
 public:
   SFE_MAX1704X(sfe_max1704x_devices_e device = MAX1704X_MAX17043); // Default to the 5V MAX17043
 
+  // Change the device type if required. Do this after instantiation but before .begin
+  void setDevice(sfe_max1704x_devices_e device);
+
+  // Allow _i2CPort to be set manually, so that isConnected can be called before .begin if required
+  void setWirePort(TwoWire &wirePort);
+
   // begin() - Initializes the MAX17043.
-  boolean begin(TwoWire &wirePort = Wire); //Returns true if module is detected
+  bool begin(TwoWire &wirePort = Wire); //Returns true if module is detected
 
   //Returns true if device is present
-  boolean isConnected(void);
+  bool isConnected(void);
 
   // Debug
   void enableDebugging(Stream &debugPort = Serial); // enable debug messages
@@ -381,7 +387,7 @@ private:
 
   #if MAX1704X_ENABLE_DEBUGLOG
   Stream *_debugPort;          //The stream to send debug messages to if enabled. Usually Serial.
-  boolean _printDebug = false; //Flag to print debugging variables
+  bool _printDebug = false; //Flag to print debugging variables
   #endif // if MAX1704X_ENABLE_DEBUGLOG
 
   // Clear the specified bit(s) in the MAX17048/49 status register


### PR DESCRIPTION
```setDevice``` allows the device type to be changed after instantiation, before ```begin```
```setWirePort``` allows the wire port to be set, so that ```isConnected``` can be called before ```begin```
Change ```boolean``` to ```bool```